### PR TITLE
Cookie dance [TB-221]

### DIFF
--- a/2-collectors/scala-stream-collector/project/Dependencies.scala
+++ b/2-collectors/scala-stream-collector/project/Dependencies.scala
@@ -50,6 +50,7 @@ object Dependencies {
     // Using the newest version of spec (2.3.6) causes
     // conflicts with `spray` for `com.chuusai.shapeless`
     val specs2           = "2.2.3"
+    val mockito          = "1.9.5"
   }
 
   object Libraries {
@@ -77,7 +78,7 @@ object Dependencies {
     val json4sJackson    = "org.json4s"            %% "json4s-jackson"            % V.json4s
 
     // Scala (test only)
-    val mockito          = "org.mockito"           %  "mockito-all"               % "1.9.5"    % "test"
+    val mockito          = "org.mockito"           %  "mockito-all"               % V.mockito  % "test"
     val specs2           = "org.specs2"            %% "specs2"                    % V.specs2   % "test"
     val sprayTestkit     = "io.spray"              %% "spray-testkit"             % V.spray    % "test"
   }

--- a/2-collectors/scala-stream-collector/project/Dependencies.scala
+++ b/2-collectors/scala-stream-collector/project/Dependencies.scala
@@ -77,6 +77,7 @@ object Dependencies {
     val json4sJackson    = "org.json4s"            %% "json4s-jackson"            % V.json4s
 
     // Scala (test only)
+    val mockito          = "org.mockito"           %  "mockito-all"               % "1.9.5"    % "test"
     val specs2           = "org.specs2"            %% "specs2"                    % V.specs2   % "test"
     val sprayTestkit     = "io.spray"              %% "spray-testkit"             % V.spray    % "test"
   }

--- a/2-collectors/scala-stream-collector/project/ScalaCollectorBuild.scala
+++ b/2-collectors/scala-stream-collector/project/ScalaCollectorBuild.scala
@@ -50,7 +50,8 @@ object ScalaCollectorBuild extends Build {
         Libraries.scalaz7,
         Libraries.snowplowRawEvent,
         Libraries.collectorPayload,
-        Libraries.json4sJackson
+        Libraries.json4sJackson,
+        Libraries.mockito
       )
     )
 }

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ResponseHandler.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ResponseHandler.scala
@@ -36,29 +36,29 @@ import Scalaz._
 
 // Spray
 import spray.http.{
-DateTime,
-HttpRequest,
-HttpResponse,
-HttpEntity,
-HttpCookie,
-SomeOrigins,
-AllOrigins,
-ContentType,
-MediaTypes,
-HttpCharsets,
-RemoteAddress
+  DateTime,
+  HttpRequest,
+  HttpResponse,
+  HttpEntity,
+  HttpCookie,
+  SomeOrigins,
+  AllOrigins,
+  ContentType,
+  MediaTypes,
+  HttpCharsets,
+  RemoteAddress
 }
 import spray.http.HttpHeaders.{
-`Location`,
-`Set-Cookie`,
-`Remote-Address`,
-`Raw-Request-URI`,
-`Content-Type`,
-`Origin`,
-`Access-Control-Allow-Origin`,
-`Access-Control-Allow-Credentials`,
-`Access-Control-Allow-Headers`,
-RawHeader
+  `Location`,
+  `Set-Cookie`,
+  `Remote-Address`,
+  `Raw-Request-URI`,
+  `Content-Type`,
+  `Origin`,
+  `Access-Control-Allow-Origin`,
+  `Access-Control-Allow-Credentials`,
+  `Access-Control-Allow-Headers`,
+  RawHeader
 }
 import spray.http.MediaTypes.`image/gif`
 
@@ -229,11 +229,11 @@ class ResponseHandler(config: CollectorConfig, sinks: CollectorSinks)(implicit c
   }
 
   /**
-  * Creates a response to the CORS preflight Options request
-  *
-  * @param request Incoming preflight Options request
-  * @return Response granting permissions to make the actual request
-  */
+   * Creates a response to the CORS preflight Options request
+   *
+   * @param request Incoming preflight Options request
+   * @return Response granting permissions to make the actual request
+   */
   def preflightResponse(request: HttpRequest) = HttpResponse().withHeaders(List(
     getAccessControlAllowOriginHeader(request),
     `Access-Control-Allow-Credentials`(true),
@@ -250,12 +250,12 @@ class ResponseHandler(config: CollectorConfig, sinks: CollectorSinks)(implicit c
   def timeout = HttpResponse(status = 500, entity = s"Request timed out.")
 
   /**
-  * Creates an Access-Control-Allow-Origin header which specifically
-  * allows the domain which made the request
-  *
-  * @param request Incoming request
-  * @return Header
-  */
+   * Creates an Access-Control-Allow-Origin header which specifically
+   * allows the domain which made the request
+   *
+   * @param request Incoming request
+   * @return Header
+   */
   private def getAccessControlAllowOriginHeader(request: HttpRequest) =
     `Access-Control-Allow-Origin`(request.headers.find {
       case `Origin`(origin) => true
@@ -266,12 +266,12 @@ class ResponseHandler(config: CollectorConfig, sinks: CollectorSinks)(implicit c
     })
 
   /**
-  * Put together a bad row ready for sinking to Kinesis
-  *
-  * @param event
-  * @param message
-  * @return Bad row
-  */
+   * Put together a bad row ready for sinking to Kinesis
+   *
+   * @param event
+   * @param message
+   * @return Bad row
+   */
   private def createBadRow(event: CollectorPayload, message: String): Array[Byte] = {
     BadRow(new String(SplitBatch.ThriftSerializer.get().serialize(event)), NonEmptyList(message)).toCompactJson.getBytes(UTF_8)
   }

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ResponseHandler.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ResponseHandler.scala
@@ -21,7 +21,9 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.UUID
 import java.net.URI
+
 import org.apache.http.client.utils.URLEncodedUtils
+import spray.http.{HttpHeader, HttpResponse, StatusCodes}
 
 // Apache Commons
 import org.apache.commons.codec.binary.Base64
@@ -35,29 +37,29 @@ import Scalaz._
 
 // Spray
 import spray.http.{
-  DateTime,
-  HttpRequest,
-  HttpResponse,
-  HttpEntity,
-  HttpCookie,
-  SomeOrigins,
-  AllOrigins,
-  ContentType,
-  MediaTypes,
-  HttpCharsets,
-  RemoteAddress
+DateTime,
+HttpRequest,
+HttpResponse,
+HttpEntity,
+HttpCookie,
+SomeOrigins,
+AllOrigins,
+ContentType,
+MediaTypes,
+HttpCharsets,
+RemoteAddress
 }
 import spray.http.HttpHeaders.{
-  `Location`,
-  `Set-Cookie`,
-  `Remote-Address`,
-  `Raw-Request-URI`,
-  `Content-Type`,
-  `Origin`,
-  `Access-Control-Allow-Origin`,
-  `Access-Control-Allow-Credentials`,
-  `Access-Control-Allow-Headers`,
-  RawHeader
+`Location`,
+`Set-Cookie`,
+`Remote-Address`,
+`Raw-Request-URI`,
+`Content-Type`,
+`Origin`,
+`Access-Control-Allow-Origin`,
+`Access-Control-Allow-Credentials`,
+`Access-Control-Allow-Headers`,
+RawHeader
 }
 import spray.http.MediaTypes.`image/gif`
 
@@ -81,9 +83,7 @@ import com.snowplowanalytics.snowplow.enrich.common.outputs.BadRow
 
 // Contains an invisible pixel to return for `/i` requests.
 object ResponseHandler {
-  val pixel = Base64.decodeBase64(
-    "R0lGODlhAQABAPAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
-  )
+  val pixel = Base64.decodeBase64("R0lGODlhAQABAPAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==")
 }
 
 // Receive requests and store data into an output sink.
@@ -96,133 +96,147 @@ class ResponseHandler(config: CollectorConfig, sinks: CollectorSinks)(implicit c
   // When `/i` is requested, this is called and stores an event in the
   // Kinisis sink and returns an invisible pixel with a cookie.
   def cookie(queryParams: String, body: String, requestCookie: Option[HttpCookie],
-      userAgent: Option[String], hostname: String, ip: RemoteAddress,
-      request: HttpRequest, refererUri: Option[String], path: String, pixelExpected: Boolean):
-      (HttpResponse, List[Array[Byte]]) = {
+             userAgent: Option[String], hostname: String, ip: RemoteAddress,
+             request: HttpRequest, refererUri: Option[String], path: String, pixelExpected: Boolean):
+  (HttpResponse, List[Array[Byte]]) = {
 
-      // Make a Tuple2 with the ip address and the shard partition key
-      val (ipAddress, partitionKey) = ip.toOption.map(_.getHostAddress) match {
-        case None     => ("unknown", UUID.randomUUID.toString)
-        case Some(ip) => (ip, if (config.useIpAddressAsPartitionKey) ip else UUID.randomUUID.toString)
-      }
+    val thirdPartyCookieParamPresent = Option(queryParams).exists(_.contains(config.thirdPartyCookiesParameter))
+    val shouldRedirect = requestCookie.isEmpty && !thirdPartyCookieParamPresent
 
-      // Use the same UUID if the request cookie contains `sp`.
-      val networkUserId: String = requestCookie match {
-        case Some(rc) => rc.content
-        case None => UUID.randomUUID.toString
-      }
+    // Make a Tuple2 with the ip address and the shard partition key
+    val (ipAddress, partitionKey) = ip.toOption.map(_.getHostAddress) match {
+      case None => ("unknown", UUID.randomUUID.toString)
+      case Some(someIp) => (someIp, if (config.useIpAddressAsPartitionKey) someIp else UUID.randomUUID.toString)
+    }
 
-      // Construct an event object from the request.
-      val timestamp: Long = System.currentTimeMillis
+    // Use the same UUID if the request cookie contains `sp`.
+    val networkUserId: String = requestCookie match {
+      case Some(rc) => rc.content
+      case None =>
+        if (thirdPartyCookieParamPresent) config.fallbackNetworkUserId
+        else UUID.randomUUID.toString
+    }
 
-      val event = new CollectorPayload(
-        "iglu:com.snowplowanalytics.snowplow/CollectorPayload/thrift/1-0-0",
-        ipAddress,
-        timestamp,
-        "UTF-8",
-        Collector
-      )
+    // Construct an event object from the request.
+    val timestamp: Long = System.currentTimeMillis
 
-      event.path = path
-      event.querystring = queryParams
-      event.body = body
-      event.hostname = hostname
-      event.networkUserId = networkUserId
+    val event = new CollectorPayload(
+      "iglu:com.snowplowanalytics.snowplow/CollectorPayload/thrift/1-0-0",
+      ipAddress,
+      timestamp,
+      "UTF-8",
+      Collector
+    )
 
-      userAgent.foreach(event.userAgent = _)
-      refererUri.foreach(event.refererUri = _)
-      event.headers = request.headers.flatMap {
-        case _: `Remote-Address` | _: `Raw-Request-URI` => None
-        case other => Some(other.toString)
-      }
+    event.path = path
+    event.querystring = queryParams
+    event.body = body
+    event.hostname = hostname
+    event.networkUserId = networkUserId
 
-      // Set the content type
-      request.headers.find(_ match {case `Content-Type`(ct) => true; case _ => false}) foreach {
+    userAgent.foreach(event.userAgent = _)
+    refererUri.foreach(event.refererUri = _)
+    event.headers = request.headers.flatMap {
+      case _: `Remote-Address` | _: `Raw-Request-URI` => None
+      case other => Some(other.toString)
+    }
 
-        // toLowerCase called because Spray seems to convert "utf" to "UTF"
-        ct => event.contentType = ct.value.toLowerCase
-      }
+    // Set the content type
+    request.headers.find { case `Content-Type`(ct) => true; case _ => false } foreach {
 
-      // Only send to Kinesis if we aren't shutting down
-      val sinkResponse = if (!KinesisSink.shuttingDown) {
+      // toLowerCase called because Spray seems to convert "utf" to "UTF"
+      ct => event.contentType = ct.value.toLowerCase
+    }
 
-        // Split events into Good and Bad
-        val eventSplit = SplitBatch.splitAndSerializePayload(event, sinks.good.MaxBytes)
+    // Only send to Kinesis if we aren't shutting down
+    val sinkResponse = if (!KinesisSink.shuttingDown) {
 
-        // Send events to respective sinks
-        val sinkResponseGood = sinks.good.storeRawEvents(eventSplit.good, partitionKey)
-        val sinkResponseBad  = sinks.bad.storeRawEvents(eventSplit.bad, partitionKey)
+      // Split events into Good and Bad
+      val eventSplit = SplitBatch.splitAndSerializePayload(event, sinks.good.MaxBytes)
 
-        // Sink Responses for Test Sink
-        sinkResponseGood ++ sinkResponseBad
-      } else {
-        null
-      }
+      // Send events to respective sinks
+      val sinkResponseGood = sinks.good.storeRawEvents(eventSplit.good, partitionKey)
+      val sinkResponseBad = sinks.bad.storeRawEvents(eventSplit.bad, partitionKey)
 
-      val policyRef = config.p3pPolicyRef
-      val CP = config.p3pCP
+      // Sink Responses for Test Sink
+      sinkResponseGood ++ sinkResponseBad
+    } else {
+      null
+    }
 
-      val headersWithoutCookie = List(
-        RawHeader("P3P", "policyref=\"%s\", CP=\"%s\"".format(policyRef, CP)),
-        getAccessControlAllowOriginHeader(request),
-        `Access-Control-Allow-Credentials`(true)
-      )
+    val headers = composeHeaders(request, shouldRedirect, networkUserId)
 
-      val headers = config.cookieConfig match {
-        case Some(cookieConfig) =>
-          val responseCookie = HttpCookie(
-            cookieConfig.name, networkUserId,
-            expires=Some(DateTime.now + cookieConfig.expiration),
-            domain=cookieConfig.domain
-          )
-          `Set-Cookie`(responseCookie) :: headersWithoutCookie
-        case None => headersWithoutCookie
-      }
-
-      val (httpResponse, badQsResponse) = if (path startsWith "/r/") {
-        // A click redirect
-        try {
-          // TODO: log errors to Kinesis as BadRows
-          val target = URLEncodedUtils.parse(URI.create("?" + queryParams), "UTF-8")
-            .find(_.getName == "u")
-            .map(_.getValue)
-          target match {
-            case Some(t) => HttpResponse(302).withHeaders(`Location`(t) :: headers) -> Nil
-            // case None => badRequest -> sinks.bad.storeRawEvents(List("TODO".getBytes), partitionKey)
-            case None => {
-              val everythingSerialized = new String(SplitBatch.ThriftSerializer.get().serialize(event))
-              badRequest -> sinks.bad.storeRawEvents(List(createBadRow(event, s"Redirect failed due to lack of u parameter")), partitionKey)
-            }
-          }
-        } catch {
-          case NonFatal(e) => {
+    val (httpResponse, badQsResponse) = if (path startsWith "/r/") {
+      // A click redirect
+      try {
+        // TODO: log errors to Kinesis as BadRows
+        val target = URLEncodedUtils.parse(URI.create("?" + queryParams), "UTF-8")
+          .find(_.getName == "u")
+          .map(_.getValue)
+        target match {
+          case Some(t) => HttpResponse(302).withHeaders(`Location`(t) :: headers) -> Nil
+          // case None => badRequest -> sinks.bad.storeRawEvents(List("TODO".getBytes), partitionKey)
+          case None => {
             val everythingSerialized = new String(SplitBatch.ThriftSerializer.get().serialize(event))
-            badRequest -> sinks.bad.storeRawEvents(List(createBadRow(event, s"Redirect failed due to error $e")), partitionKey)
+            badRequest -> sinks.bad.storeRawEvents(List(createBadRow(event, s"Redirect failed due to lack of u parameter")), partitionKey)
           }
         }
-      } else if (KinesisSink.shuttingDown) {
-        // So that the tracker knows the request failed and can try to resend later
-        notFound -> Nil
-      } else (if (pixelExpected) {
-        HttpResponse(entity = HttpEntity(`image/gif`, ResponseHandler.pixel))
+      } catch {
+        case NonFatal(e) => {
+          val everythingSerialized = new String(SplitBatch.ThriftSerializer.get().serialize(event))
+          badRequest -> sinks.bad.storeRawEvents(List(createBadRow(event, s"Redirect failed due to error $e")), partitionKey)
+        }
+      }
+    } else if (KinesisSink.shuttingDown) {
+      // So that the tracker knows the request failed and can try to resend later
+      notFound -> Nil
+    } else {
+      if (pixelExpected) {
+        if (shouldRedirect) HttpResponse(StatusCodes.Found) else HttpResponse(entity = HttpEntity(`image/gif`, ResponseHandler.pixel))
       } else {
         // See https://github.com/snowplow/snowplow-javascript-tracker/issues/482
         HttpResponse(entity = "ok")
-      }).withHeaders(headers) -> Nil
+      }
+    }.withHeaders(headers) -> Nil
 
-      (httpResponse, badQsResponse ++ sinkResponse)
+    (httpResponse, badQsResponse ++ sinkResponse)
+  }
+
+  private def composeHeaders(request: HttpRequest, shouldRedirect: Boolean, networkUserId: String) = {
+    val headersWithoutCookie = List(
+      RawHeader("P3P", "policyref=\"%s\", CP=\"%s\"".format(config.p3pPolicyRef, config.p3pCP)),
+      getAccessControlAllowOriginHeader(request),
+      `Access-Control-Allow-Credentials`(true)
+    )
+
+    val resolvedCookies = config.cookieConfig match {
+      case Some(cookieConfig) =>
+        val responseCookie = HttpCookie(
+          cookieConfig.name, networkUserId,
+          expires = Some(DateTime.now + cookieConfig.expiration),
+          domain = cookieConfig.domain
+        )
+        `Set-Cookie`(responseCookie) :: headersWithoutCookie
+      case None => headersWithoutCookie
     }
 
+    val headers = if (shouldRedirect) {
+      val redirect = request.uri.withQuery(Map(config.thirdPartyCookiesParameter -> "true"))
+      `Location`(redirect) :: resolvedCookies
+    } else resolvedCookies
+    headers
+  }
+
   /**
-   * Creates a response to the CORS preflight Options request
-   *
-   * @param request Incoming preflight Options request
-   * @return Response granting permissions to make the actual request
-   */
+    * Creates a response to the CORS preflight Options request
+    *
+    * @param request Incoming preflight Options request
+    * @return Response granting permissions to make the actual request
+    */
   def preflightResponse(request: HttpRequest) = HttpResponse().withHeaders(List(
     getAccessControlAllowOriginHeader(request),
     `Access-Control-Allow-Credentials`(true),
-    `Access-Control-Allow-Headers`( "Content-Type")))
+    `Access-Control-Allow-Headers`("Content-Type")))
 
   def flashCrossDomainPolicy = HttpEntity(
     contentType = ContentType(MediaTypes.`text/xml`, HttpCharsets.`ISO-8859-1`),
@@ -230,33 +244,36 @@ class ResponseHandler(config: CollectorConfig, sinks: CollectorSinks)(implicit c
   )
 
   def healthy = HttpResponse(status = 200, entity = s"OK")
+
   def badRequest = HttpResponse(status = 400, entity = "400 Bad request")
+
   def notFound = HttpResponse(status = 404, entity = "404 Not found")
+
   def timeout = HttpResponse(status = 500, entity = s"Request timed out.")
 
   /**
-   * Creates an Access-Control-Allow-Origin header which specifically
-   * allows the domain which made the request
-   *
-   * @param request Incoming request
-   * @return Header
-   */
+    * Creates an Access-Control-Allow-Origin header which specifically
+    * allows the domain which made the request
+    *
+    * @param request Incoming request
+    * @return Header
+    */
   private def getAccessControlAllowOriginHeader(request: HttpRequest) =
-    `Access-Control-Allow-Origin`(request.headers.find(_ match {
+    `Access-Control-Allow-Origin`(request.headers.find {
       case `Origin`(origin) => true
       case _ => false
-    }) match {
+    } match {
       case Some(`Origin`(origin)) => SomeOrigins(origin)
       case _ => AllOrigins
     })
 
   /**
-   * Put together a bad row ready for sinking to Kinesis
-   *
-   * @param event
-   * @param message
-   * @return Bad row
-   */
+    * Put together a bad row ready for sinking to Kinesis
+    *
+    * @param event
+    * @param message
+    * @return Bad row
+    */
   private def createBadRow(event: CollectorPayload, message: String): Array[Byte] = {
     BadRow(new String(SplitBatch.ThriftSerializer.get().serialize(event)), NonEmptyList(message)).toCompactJson.getBytes(UTF_8)
   }

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ResponseHandler.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ResponseHandler.scala
@@ -21,7 +21,6 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.UUID
 import java.net.URI
-
 import org.apache.http.client.utils.URLEncodedUtils
 import spray.http.{HttpHeader, HttpResponse, StatusCodes}
 
@@ -83,7 +82,9 @@ import com.snowplowanalytics.snowplow.enrich.common.outputs.BadRow
 
 // Contains an invisible pixel to return for `/i` requests.
 object ResponseHandler {
-  val pixel = Base64.decodeBase64("R0lGODlhAQABAPAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==")
+  val pixel = Base64.decodeBase64(
+    "R0lGODlhAQABAPAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
+  )
 }
 
 // Receive requests and store data into an output sink.
@@ -228,11 +229,11 @@ class ResponseHandler(config: CollectorConfig, sinks: CollectorSinks)(implicit c
   }
 
   /**
-    * Creates a response to the CORS preflight Options request
-    *
-    * @param request Incoming preflight Options request
-    * @return Response granting permissions to make the actual request
-    */
+  * Creates a response to the CORS preflight Options request
+  *
+  * @param request Incoming preflight Options request
+  * @return Response granting permissions to make the actual request
+  */
   def preflightResponse(request: HttpRequest) = HttpResponse().withHeaders(List(
     getAccessControlAllowOriginHeader(request),
     `Access-Control-Allow-Credentials`(true),
@@ -244,20 +245,17 @@ class ResponseHandler(config: CollectorConfig, sinks: CollectorSinks)(implicit c
   )
 
   def healthy = HttpResponse(status = 200, entity = s"OK")
-
   def badRequest = HttpResponse(status = 400, entity = "400 Bad request")
-
   def notFound = HttpResponse(status = 404, entity = "404 Not found")
-
   def timeout = HttpResponse(status = 500, entity = s"Request timed out.")
 
   /**
-    * Creates an Access-Control-Allow-Origin header which specifically
-    * allows the domain which made the request
-    *
-    * @param request Incoming request
-    * @return Header
-    */
+  * Creates an Access-Control-Allow-Origin header which specifically
+  * allows the domain which made the request
+  *
+  * @param request Incoming request
+  * @return Header
+  */
   private def getAccessControlAllowOriginHeader(request: HttpRequest) =
     `Access-Control-Allow-Origin`(request.headers.find {
       case `Origin`(origin) => true
@@ -268,12 +266,12 @@ class ResponseHandler(config: CollectorConfig, sinks: CollectorSinks)(implicit c
     })
 
   /**
-    * Put together a bad row ready for sinking to Kinesis
-    *
-    * @param event
-    * @param message
-    * @return Bad row
-    */
+  * Put together a bad row ready for sinking to Kinesis
+  *
+  * @param event
+  * @param message
+  * @return Bad row
+  */
   private def createBadRow(event: CollectorPayload, message: String): Array[Byte] = {
     BadRow(new String(SplitBatch.ThriftSerializer.get().serialize(event)), NonEmptyList(message)).toCompactJson.getBytes(UTF_8)
   }

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ResponseHandler.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ResponseHandler.scala
@@ -102,7 +102,7 @@ class ResponseHandler(config: CollectorConfig, sinks: CollectorSinks)(implicit c
   (HttpResponse, List[Array[Byte]]) = {
 
     val thirdPartyCookieParamPresent = Option(queryParams).exists(_.contains(config.thirdPartyCookiesParameter))
-    val shouldRedirect = requestCookie.isEmpty && !thirdPartyCookieParamPresent && pixelExpected
+    val shouldRedirect = config.n3pcRedirectEnabled && requestCookie.isEmpty && !thirdPartyCookieParamPresent && pixelExpected
 
     // Make a Tuple2 with the ip address and the shard partition key
     val (ipAddress, partitionKey) = ip.toOption.map(_.getHostAddress) match {

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ResponseHandler.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ResponseHandler.scala
@@ -150,8 +150,7 @@ class ResponseHandler(config: CollectorConfig, sinks: CollectorSinks)(implicit c
     }
 
     // Only send to Kinesis if we aren't shutting down or we're expecting a redirect
-    val sinkResponse = if (!KinesisSink.shuttingDown || shouldRedirect) {
-
+    val sinkResponse = if (!shouldRedirect && !KinesisSink.shuttingDown) {
       // Split events into Good and Bad
       val eventSplit = SplitBatch.splitAndSerializePayload(event, sinks.good.MaxBytes)
 
@@ -162,7 +161,7 @@ class ResponseHandler(config: CollectorConfig, sinks: CollectorSinks)(implicit c
       // Sink Responses for Test Sink
       sinkResponseGood ++ sinkResponseBad
     } else {
-      null
+      Nil
     }
 
     val headers = composeHeaders(request, shouldRedirect, networkUserId)

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ResponseHandler.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ResponseHandler.scala
@@ -149,8 +149,8 @@ class ResponseHandler(config: CollectorConfig, sinks: CollectorSinks)(implicit c
       ct => event.contentType = ct.value.toLowerCase
     }
 
-    // Only send to Kinesis if we aren't shutting down
-    val sinkResponse = if (!KinesisSink.shuttingDown) {
+    // Only send to Kinesis if we aren't shutting down or we're expecting a redirect
+    val sinkResponse = if (!KinesisSink.shuttingDown || shouldRedirect) {
 
       // Split events into Good and Bad
       val eventSplit = SplitBatch.splitAndSerializePayload(event, sinks.good.MaxBytes)

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ResponseHandler.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ResponseHandler.scala
@@ -102,7 +102,7 @@ class ResponseHandler(config: CollectorConfig, sinks: CollectorSinks)(implicit c
   (HttpResponse, List[Array[Byte]]) = {
 
     val thirdPartyCookieParamPresent = Option(queryParams).exists(_.contains(config.thirdPartyCookiesParameter))
-    val shouldRedirect = requestCookie.isEmpty && !thirdPartyCookieParamPresent
+    val shouldRedirect = requestCookie.isEmpty && !thirdPartyCookieParamPresent && pixelExpected
 
     // Make a Tuple2 with the ip address and the shard partition key
     val (ipAddress, partitionKey) = ip.toOption.map(_.getHostAddress) match {

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ScalaCollectorApp.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ScalaCollectorApp.scala
@@ -154,6 +154,9 @@ class CollectorConfig(config: Config) {
   val port = collector.getInt("port")
   val production = collector.getBoolean("production")
 
+  val thirdPartyCookiesParameter = collector.getOptionalString("third-party-cookie-param").getOrElse("n3pc")
+  val fallbackNetworkUserId = collector.getOptionalString("fallback-network-id").getOrElse("00000000-0000-4000-A000-000000000000")
+
   private val p3p = collector.getConfig("p3p")
   val p3pPolicyRef = p3p.getString("policyref")
   val p3pCP = p3p.getString("CP")
@@ -206,4 +209,6 @@ class CollectorConfig(config: Config) {
   def cookieName = cookieConfig.map(_.name)
   def cookieDomain = cookieConfig.flatMap(_.domain)
   def cookieExpiration = cookieConfig.map(_.expiration)
+
+
 }

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ScalaCollectorApp.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ScalaCollectorApp.scala
@@ -125,11 +125,11 @@ object ScalaCollector extends App {
 // Return Options from the configuration.
 object Helper {
   implicit class RichConfig(val underlying: Config) extends AnyVal {
-    def getOptionalString(path: String): Option[String] = try {
-      Some(underlying.getString(path))
-    } catch {
-      case e: ConfigException.Missing => None
-    }
+    def catchMissing = util.control.Exception.catching(classOf[ConfigException.Missing])
+
+    def getOptionalString(path: String): Option[String] = catchMissing opt underlying.getString(path)
+
+    def getOptionalBoolean(path: String): Option[Boolean] = catchMissing opt underlying.getBoolean(path)
   }
 }
 
@@ -154,6 +154,8 @@ class CollectorConfig(config: Config) {
   val port = collector.getInt("port")
   val production = collector.getBoolean("production")
 
+  //Third party cookie config params.
+  val n3pcRedirectEnabled = collector.getOptionalBoolean("third-party-redirect-enabled").getOrElse(false)
   val thirdPartyCookiesParameter = collector.getOptionalString("third-party-cookie-param").getOrElse("n3pc")
   val fallbackNetworkUserId = collector.getOptionalString("fallback-network-id").getOrElse("00000000-0000-4000-A000-000000000000")
 

--- a/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ScalaCollectorApp.scala
+++ b/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ScalaCollectorApp.scala
@@ -209,6 +209,4 @@ class CollectorConfig(config: Config) {
   def cookieName = cookieConfig.map(_.name)
   def cookieDomain = cookieConfig.flatMap(_.domain)
   def cookieExpiration = cookieConfig.map(_.expiration)
-
-
 }

--- a/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
+++ b/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
@@ -17,6 +17,7 @@ package collectors
 package scalastream
 
 // Scala
+import org.specs2.mock.Mockito
 import spray.http.StatusCodes
 
 import scala.collection.mutable.MutableList
@@ -43,7 +44,7 @@ import org.apache.thrift.TDeserializer
 import sinks._
 import CollectorPayload.thrift.model1.CollectorPayload
 
-class CollectorServiceSpec extends Specification with Specs2RouteTest with
+class CollectorServiceSpec extends Specification with Specs2RouteTest with Mockito with
      AnyMatchers {
    val testConf: Config = ConfigFactory.parseString("""
 collector {
@@ -91,7 +92,11 @@ collector {
 }
 """)
   val collectorConfig = new CollectorConfig(testConf)
-  val sink = new TestSink
+  val sink = smartMock[AbstractSink]
+  sink.storeRawEvents(any[List[Array[Byte]]], anyString).answers{(params, mock) => params match {
+      case Array(firstArg, drugi) => firstArg.asInstanceOf[List[Array[Byte]]]
+    }
+  }
   val sinks = CollectorSinks(sink, sink)
   val responseHandler = new ResponseHandler(collectorConfig, sinks)
   val collectorService = new CollectorService(collectorConfig, responseHandler, system)
@@ -113,6 +118,7 @@ collector {
     "return a redirect with n3pc parameter " in {
       CollectorGet("/i") ~> collectorService.collectorRoute ~> check {
         response.status.mustEqual(StatusCodes.Found)
+        there was no(sink).storeRawEvents(any, any)
         val locationHeader: String = header("Location").get.value
         locationHeader must contain(collectorConfig.thirdPartyCookiesParameter)
       }
@@ -124,6 +130,7 @@ collector {
         val httpCookies: List[HttpCookie] = headers.collect {
           case `Set-Cookie`(hc) => hc
         }
+        there was atLeastThree(sink).storeRawEvents(any, any)
         httpCookies must not be empty
         val httpCookie = httpCookies.head
         httpCookie.content mustEqual collectorConfig.fallbackNetworkUserId
@@ -136,6 +143,7 @@ collector {
         val httpCookies: List[HttpCookie] = headers.collect {
           case `Set-Cookie`(hc) => hc
         }
+        there was atLeastThree(sink).storeRawEvents(any, any)
         val httpCookie = httpCookies.head
         httpCookie.content must beEqualTo("UUID_Test")
       }
@@ -199,10 +207,22 @@ collector {
           "policyref=\"%s\", CP=\"%s\"".format(policyRef, CP))
       }
     }
-    "store the expected event as a serialized Thrift object in the enabled sink" in {
+
+    "do not store the expected event if there's no cookie" in {
       val payloadData = "param1=val1&param2=val2"
       val storedRecordBytes = responseHandler.cookie(payloadData, null, None,
         None, "localhost", RemoteAddress("127.0.0.1"), new HttpRequest(), None, "/i", pixelExpected = true)._2
+      storedRecordBytes must beEmpty
+    }
+
+    "store the expected event as a serialized Thrift object in the enabled sink only if cookie is present" in {
+      val payloadData = "param1=val1&param2=val2"
+      val sink = new TestSink
+      val sinks = CollectorSinks(sink, sink)
+      val responseHandler = new ResponseHandler(collectorConfig, sinks)
+      val cookie = HttpCookie("SomeName",  "SOME_UUID")
+      val storedRecordBytes = responseHandler.cookie(payloadData, null, Some(cookie),
+        None, "localhost", RemoteAddress("127.0.0.1"), new HttpRequest(), None, s"/i", pixelExpected = true)._2
 
       val storedEvent = new CollectorPayload
       this.synchronized {

--- a/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
+++ b/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
@@ -167,11 +167,7 @@ collector {
     }
 
     "return an invisible pixel" in {
-      val sink = smartMock[AbstractSink]
-      sink.storeRawEvents(any[List[Array[Byte]]], anyString).answers{(params, mock) => params match {
-        case Array(firstArg, secondArg) => firstArg.asInstanceOf[List[Array[Byte]]]
-      }
-      }
+      val sink = new TestSink
       val sinks = CollectorSinks(sink, sink)
       val responseHandler = new ResponseHandler(collectorConfig, sinks)
       val collectorService = new CollectorService(collectorConfig, responseHandler, system)
@@ -181,11 +177,7 @@ collector {
     }
 
     "return a cookie expiring at the correct time" in {
-      val sink = smartMock[AbstractSink]
-      sink.storeRawEvents(any[List[Array[Byte]]], anyString).answers{(params, mock) => params match {
-        case Array(firstArg, secondArg) => firstArg.asInstanceOf[List[Array[Byte]]]
-      }
-      }
+      val sink = new TestSink
       val sinks = CollectorSinks(sink, sink)
       val responseHandler = new ResponseHandler(collectorConfig, sinks)
       val collectorService = new CollectorService(collectorConfig, responseHandler, system)
@@ -213,11 +205,7 @@ collector {
       }
     }
     "return the same cookie as passed in" in {
-      val sink = smartMock[AbstractSink]
-      sink.storeRawEvents(any[List[Array[Byte]]], anyString).answers{(params, mock) => params match {
-        case Array(firstArg, secondArg) => firstArg.asInstanceOf[List[Array[Byte]]]
-      }
-      }
+      val sink = new TestSink
       val sinks = CollectorSinks(sink, sink)
       val responseHandler = new ResponseHandler(collectorConfig, sinks)
       val collectorService = new CollectorService(collectorConfig, responseHandler, system)
@@ -235,11 +223,7 @@ collector {
       }
     }
     "return a P3P header" in {
-      val sink = smartMock[AbstractSink]
-      sink.storeRawEvents(any[List[Array[Byte]]], anyString).answers{(params, mock) => params match {
-          case Array(firstArg, secondArg) => firstArg.asInstanceOf[List[Array[Byte]]]
-        }
-      }
+      val sink = new TestSink
       val sinks = CollectorSinks(sink, sink)
       val responseHandler = new ResponseHandler(collectorConfig, sinks)
       val collectorService = new CollectorService(collectorConfig, responseHandler, system)
@@ -258,11 +242,7 @@ collector {
     }
 
     "do not store the expected event if there's no cookie" in {
-      val sink = smartMock[AbstractSink]
-      sink.storeRawEvents(any[List[Array[Byte]]], anyString).answers{(params, mock) => params match {
-        case Array(firstArg, secondArg) => firstArg.asInstanceOf[List[Array[Byte]]]
-      }
-      }
+      val sink = new TestSink
       val sinks = CollectorSinks(sink, sink)
       val responseHandler = new ResponseHandler(collectorConfig, sinks)
 

--- a/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
+++ b/2-collectors/scala-stream-collector/src/test/scala/com.snowplowanalytics.snowplow.collectors.scalastream/CollectorServiceSpec.scala
@@ -46,13 +46,15 @@ import CollectorPayload.thrift.model1.CollectorPayload
 
 class CollectorServiceSpec extends Specification with Specs2RouteTest with Mockito with
      AnyMatchers {
-   val testConf: Config = ConfigFactory.parseString("""
+
+
+   def testConf(n3pcEnabled: Boolean): Config = ConfigFactory.parseString(s"""
 collector {
   interface = "0.0.0.0"
   port = 8080
 
   production = true
-
+  third-party-redirect-enabled = $n3pcEnabled
   p3p {
     policyref = "/w3c/p3p.xml"
     CP = "NOI DSP COR NID PSA OUR IND COM NAV STA"
@@ -91,21 +93,21 @@ collector {
   }
 }
 """)
-  val collectorConfig = new CollectorConfig(testConf)
 
-  // By default, spray will always add Remote-Address to every request
-  // when running with the `spray.can.server.remote-address-header`
-  // option. However, the testing does not read this option and a
-  // remote address always needs to be set.
-  def CollectorGet(uri: String, cookie: Option[`HttpCookie`] = None,
-      remoteAddr: String = "127.0.0.1") = {
-    val headers: MutableList[HttpHeader] =
-      MutableList(`Remote-Address`(remoteAddr),`Raw-Request-URI`(uri))
-    cookie.foreach(headers += `Cookie`(_))
-    Get(uri).withHeaders(headers.toList)
-  }
+  "Snowplow's Scala collector with n3pc redirect " should {
+    val collectorConfig = new CollectorConfig(testConf(n3pcEnabled = true))
 
-  "Snowplow's Scala collector" should {
+    // By default, spray will always add Remote-Address to every request
+    // when running with the `spray.can.server.remote-address-header`
+    // option. However, the testing does not read this option and a
+    // remote address always needs to be set.
+    def CollectorGet(uri: String, cookie: Option[`HttpCookie`] = None,
+                     remoteAddr: String = "127.0.0.1") = {
+      val headers: MutableList[HttpHeader] =
+        MutableList(`Remote-Address`(remoteAddr),`Raw-Request-URI`(uri))
+      cookie.foreach(headers += `Cookie`(_))
+      Get(uri).withHeaders(headers.toList)
+    }
     "return a redirect with n3pc parameter " in {
       val sink = smartMock[AbstractSink]
       sink.storeRawEvents(any[List[Array[Byte]]], anyString).answers{(params, mock) => params match {
@@ -292,6 +294,102 @@ collector {
       CollectorGet("/health") ~> collectorService.collectorRoute ~> check {
         response.status must beEqualTo(spray.http.StatusCodes.OK)
       }
+    }
+  }
+
+  "Snowplow's Scala collector with n3pc redirect disabled" should {
+    val collectorConfig = new CollectorConfig(testConf(n3pcEnabled = false))
+
+    // By default, spray will always add Remote-Address to every request
+    // when running with the `spray.can.server.remote-address-header`
+    // option. However, the testing does not read this option and a
+    // remote address always needs to be set.
+    def CollectorGet(uri: String, cookie: Option[`HttpCookie`] = None,
+                     remoteAddr: String = "127.0.0.1") = {
+      val headers: MutableList[HttpHeader] =
+        MutableList(`Remote-Address`(remoteAddr),`Raw-Request-URI`(uri))
+      cookie.foreach(headers += `Cookie`(_))
+      Get(uri).withHeaders(headers.toList)
+    }
+    val sink = new TestSink
+    val sinks = CollectorSinks(sink, sink)
+    val responseHandler = new ResponseHandler(collectorConfig, sinks)
+    val collectorService = new CollectorService(collectorConfig, responseHandler, system)
+    val thriftDeserializer = new TDeserializer
+    "return an invisible pixel" in {
+      CollectorGet("/i") ~> collectorService.collectorRoute ~> check {
+        response.status.mustEqual(StatusCodes.OK)
+        responseAs[Array[Byte]] === ResponseHandler.pixel
+      }
+    }
+    "return a cookie expiring at the correct time" in {
+      CollectorGet("/i") ~> collectorService.collectorRoute ~> check {
+        headers must not be empty
+
+        val httpCookies: List[HttpCookie] = headers.collect {
+          case `Set-Cookie`(hc) => hc
+        }
+        httpCookies must not be empty
+
+        // Assume we only return a single cookie.
+        // If the collector is modified to return multiple cookies,
+        // this will need to be changed.
+        val httpCookie = httpCookies(0)
+
+        httpCookie.name must beEqualTo(collectorConfig.cookieName.get)
+        httpCookie.domain must beSome
+        httpCookie.domain.get must be(collectorConfig.cookieDomain.get)
+        httpCookie.expires must beSome
+        val expiration = httpCookie.expires.get
+        val offset = expiration.clicks - collectorConfig.cookieExpiration.get -
+          DateTime.now.clicks
+        offset.asInstanceOf[Int] must beCloseTo(0, 3600000) // 1 hour window.
+      }
+    }
+    "return the same cookie as passed in" in {
+      CollectorGet("/i", Some(HttpCookie(collectorConfig.cookieName.get, "UUID_Test"))) ~>
+        collectorService.collectorRoute ~> check {
+        val httpCookies: List[HttpCookie] = headers.collect {
+          case `Set-Cookie`(hc) => hc
+        }
+        // Assume we only return a single cookie.
+        // If the collector is modified to return multiple cookies,
+        // this will need to be changed.
+        val httpCookie = httpCookies(0)
+
+        httpCookie.content must beEqualTo("UUID_Test")
+      }
+    }
+    "return a P3P header" in {
+      CollectorGet("/i") ~> collectorService.collectorRoute ~> check {
+        val p3pHeaders = headers.filter {
+          h => h.name.equals("P3P")
+        }
+        p3pHeaders.size must beEqualTo(1)
+        val p3pHeader = p3pHeaders(0)
+
+        val policyRef = collectorConfig.p3pPolicyRef
+        val CP = collectorConfig.p3pCP
+        p3pHeader.value must beEqualTo(
+          "policyref=\"%s\", CP=\"%s\"".format(policyRef, CP))
+      }
+    }
+    "store the expected event as a serialized Thrift object in the enabled sink" in {
+      val payloadData = "param1=val1&param2=val2"
+      val storedRecordBytes = responseHandler.cookie(payloadData, null, None,
+        None, "localhost", RemoteAddress("127.0.0.1"), new HttpRequest(), None, "/i", true)._2
+
+      val storedEvent = new CollectorPayload
+      this.synchronized {
+        thriftDeserializer.deserialize(storedEvent, storedRecordBytes.head)
+      }
+
+      storedEvent.timestamp must beCloseTo(DateTime.now.clicks, 60000)
+      storedEvent.encoding must beEqualTo("UTF-8")
+      storedEvent.ipAddress must beEqualTo("127.0.0.1")
+      storedEvent.collector must beEqualTo("ssc-0.7.0-test")
+      storedEvent.path must beEqualTo("/i")
+      storedEvent.querystring must beEqualTo(payloadData)
     }
   }
 }


### PR DESCRIPTION
The flow goes like this.... Request is received, and if it does not exits, the 3rd party cookie is added and request is redirected back to /i with a n3pc parameter. Then a check is done if it was a redirect with n3pc and if the cookie was properly set. If it wasn't, obviously the browser does not accept 3rd party cookies and the fallbackNetworkId is set.
